### PR TITLE
Fix nipple layout error

### DIFF
--- a/projects/ngx-joystick/src/lib/ngx-joystick.component.ts
+++ b/projects/ngx-joystick/src/lib/ngx-joystick.component.ts
@@ -34,13 +34,13 @@ export class NgxJoystickComponent implements OnInit, OnDestroy {
   @Output() plainRight = new EventEmitter<JoystickEvent>();
 
   manager: nipplejs.JoystickManager;
-  private interval: NodeJS.Timeout;
+  private interval: number;
 
   constructor(private el: ElementRef) {
   }
 
   ngOnInit() {
-    this.interval = setInterval(() => {
+    this.interval = window.setInterval(() => {
       if (
         this.joystickContainer &&
         this.joystickContainer.nativeElement.clientWidth &&

--- a/projects/ngx-joystick/src/lib/ngx-joystick.component.ts
+++ b/projects/ngx-joystick/src/lib/ngx-joystick.component.ts
@@ -54,13 +54,13 @@ export class NgxJoystickComponent implements OnInit, OnDestroy {
         this.manager = nipplejs.create(this.options);
         this.setupEvents();
 
-        clearInterval(this.interval);
+        window.clearInterval(this.interval);
       }
     }, 100);
   }
 
   ngOnDestroy() {
-    clearInterval(this.interval);
+    window.clearInterval(this.interval);
     this.manager.destroy();
   }
 

--- a/projects/ngx-joystick/src/lib/ngx-joystick.component.ts
+++ b/projects/ngx-joystick/src/lib/ngx-joystick.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Output, EventEmitter, Input, ElementRef, OnDestroy } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter, Input, ElementRef, OnDestroy, ViewChild } from '@angular/core';
 import * as nipplejs from 'nipplejs';
 
 export interface JoystickEvent {
@@ -9,11 +9,13 @@ export interface JoystickEvent {
 @Component({
   selector: 'ngx-joystick',
   template: `
-  <div style="width: 100%; height: 100%" id="static"></div>
+  <div #joystickContainer style="width: 100%; height: 100%" id="static"></div>
   `,
   styles: [],
 })
 export class NgxJoystickComponent implements OnInit, OnDestroy {
+  @ViewChild('joystickContainer') joystickContainer: ElementRef;
+  
   @Input() options: nipplejs.JoystickManagerOptions;
   @Output() move = new EventEmitter<JoystickEvent>();
   // tslint:disable-next-line:no-output-native
@@ -32,23 +34,33 @@ export class NgxJoystickComponent implements OnInit, OnDestroy {
   @Output() plainRight = new EventEmitter<JoystickEvent>();
 
   manager: nipplejs.JoystickManager;
+  private interval: NodeJS.Timeout;
 
   constructor(private el: ElementRef) {
   }
 
   ngOnInit() {
-    if (!this.options) {
-      this.options = this.getDefaultOptions();
-    } else {
-      this.options.zone = this.el.nativeElement;
-    }
+    this.interval = setInterval(() => {
+      if (
+        this.joystickContainer &&
+        this.joystickContainer.nativeElement.clientWidth &&
+        this.joystickContainer.nativeElement.clientHeight
+      ) {
+        if (!this.options) {
+            this.options = this.getDefaultOptions();
+        } else {
+            this.options.zone = this.el.nativeElement;
+        }
+        this.manager = nipplejs.create(this.options);
+        this.setupEvents();
 
-    this.manager = nipplejs.create(this.options);
-
-    this.setupEvents();
+        clearInterval(this.interval);
+      }
+    }, 100);
   }
 
   ngOnDestroy() {
+    clearInterval(this.interval);
     this.manager.destroy();
   }
 


### PR DESCRIPTION
When container is not fully initialized, clicking on the nipple will cause it to shoot out.
But after resizing the window, it works as expected.

According to https://github.com/yoannmoinet/nipplejs/issues/39